### PR TITLE
Use Meteor's default Promise polyfill

### DIFF
--- a/package.js
+++ b/package.js
@@ -14,7 +14,6 @@ Package.registerBuildPlugin({
     npmDependencies: {
         'source-map': '0.5.3',
         'postcss': '5.0.12',
-        'es6-promise': '3.0.2',
         'app-module-path': '1.0.5'
     },
     sources: [

--- a/plugin/minify-css.js
+++ b/plugin/minify-css.js
@@ -1,5 +1,3 @@
-Npm.require('es6-promise').polyfill();
-
 var appModulePath = Npm.require('app-module-path');
 appModulePath.addPath(process.cwd() + '/packages/npm-container/.npm/package/node_modules/');
 


### PR DESCRIPTION
In Meteor 1.3, the command line tool relies heavily on promises from https://github.com/meteor/promise. When there is a global polyfill in a build plugin, the tool breaks.

As far as I can tell, this package works just fine without that polyfill!
