### PR TITLE
bump postcss and postcss-load-config compatibility version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Read more below...
 3. Add peer NPM dependencies
 
    ```sh
-   meteor npm install --save-dev postcss@6.0.22 postcss-load-config@1.2.0
+   meteor npm install --save-dev postcss@8.3.5 postcss-load-config@3.1.0
    ```
 
 4. Add PostCSS plugins:
@@ -218,6 +218,7 @@ MIT
 
 ## Changelog
 
+- v2.0.8 Update postcss to 8.3.x and postcss-load-config to 3.1.x
 - v2.0.6 Update tmeasday:check-npm-versions dep to 1.0.1
 - v2.0.5 Update/fix dependency checks
 - v2.0.3 Restoring the use of app-module-path

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Minifier for Meteor with PostCSS processing - use Autoprefixer and others with ease',
-  version: '2.0.7',
+  version: '2.0.8',
   name: 'juliancwirko:postcss',
   git: 'https://github.com/juliancwirko/meteor-postcss.git'
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "postcss": "^8.2.10",
-    "postcss-load-config": "^3.0.1"
+    "postcss": "^8.3.0",
+    "postcss-load-config": "^3.1.0"
   }
 }

--- a/plugin/minify-css.js
+++ b/plugin/minify-css.js
@@ -9,8 +9,8 @@ import Future from 'fibers/future';
 var sourcemap = Npm.require('source-map');
 
 checkNpmVersions({
-    'postcss': '8.2.x',
-    'postcss-load-config': '3.0.x'
+    'postcss': '8.3.x',
+    'postcss-load-config': '3.1.x'
 }, 'juliancwirko:postcss');
 
 // Not used, but available.


### PR DESCRIPTION
this pull request will remove warning

```
WARNING: npm peer requirements (for juliancwirko:postcss) not installed:
   - postcss@8.3.5 installed, postcss@8.2.x needed
 - postcss-load-config@3.1.0 installed, postcss-load-config@3.0.x needed

  Read more about installing npm peer dependencies:
    http://guide.meteor.com/using-packages.html#peer-npm-dependencies
```