### PR TITLE
Support postcss dependency messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ You can use it side by side with your favourite preprocessor. There is an exampl
 
 You should be able to use PostCSS plugins syntax in the .styl or .scss files too. (Tested only with Stylus).
 
+## Tailwind CSS
+
+Tailwind CSS is supported when used with Meteor `<unknown>` or newer.
+
+Since HMR applies updates to js files earlier than the css is updated, there can be a delay when using a Tailwind CSS class the first time before the styles are applied.
+
 ## Alternative configuration locations
 
 This package uses [postcss-load-config](https://github.com/michael-ciniawsky/postcss-load-config) to load

--- a/package.js
+++ b/package.js
@@ -14,7 +14,9 @@ Package.registerBuildPlugin({
   ],
   npmDependencies: {
     'source-map': '0.5.6',
-    'app-module-path': '2.2.0'
+    'app-module-path': '2.2.0',
+    'lru-cache': '6.0.0',
+    'micromatch': '4.0.4'
   },
   sources: [
     'plugin/minify-css.js'

--- a/plugin/minify-css.js
+++ b/plugin/minify-css.js
@@ -83,7 +83,7 @@ var watchAndHashDeps = Profile('watchAndHashDeps', function (deps, file) {
     deps.forEach(dep => {
         if (dep.type === 'dependency') {
             fileCount += 1;
-            const fileHash = file.readAndWatchFileWithHash(dep.file, { cache: true }).hash;
+            const fileHash = file.readAndWatchFileWithHash(dep.file).hash;
             hash.update(fileHash).update('\0');
         } else if (dep.type === 'dir-dependency') {
             if (dep.dir in globsByDir) {
@@ -110,7 +110,7 @@ var watchAndHashDeps = Profile('watchAndHashDeps', function (deps, file) {
                 if (entry.isFile() && matchers.some(isMatch => isMatch(relPath))) {
                     const absPath = path.join(absDir, entry.name);
                     fileCount += 1;
-                    hash.update(file.readAndWatchFileWithHash(absPath, { cache: true }).hash).update('\0');
+                    hash.update(file.readAndWatchFileWithHash(absPath).hash).update('\0');
                 } else if (
                     entry.isDirectory() && entry.name !== 'node_modules' && entry.name !== '.meteor'
                 ) {

--- a/plugin/minify-css.js
+++ b/plugin/minify-css.js
@@ -74,6 +74,12 @@ var isNotImport = function (inputFileUrl) {
 };
 
 var watchAndHashDeps = Profile('watchAndHashDeps', function (deps, file) {
+    if (typeof file.readAndWatchFileWithHash !== 'function') {
+        DEBUG_CACHE && console.log('PostCSS: ignoring deps; old Meteor version');
+
+        return;
+    }
+
     const hash = createHash('sha1');
     const globsByDir = Object.create(null);
     let fileCount = 0;


### PR DESCRIPTION
Adds support for dependency messages: https://github.com/postcss/postcss/blob/main/docs/guidelines/runner.md#3-dependencies

It finds all files that are dependencies, and has Meteor add them to the watch set so changes to them cause a rebuild. It also uses the list of dependencies to help with caching - if the css files and the files that are dependencies were not modified it can reuse the results from the last time it minified the files.

In my test app on Windows, creating the dep cache key takes ~50ms while walking 100 folders that each have 20 files. It does this during every rebuild.

Along with https://github.com/meteor/meteor/pull/11882, this should allow using tailwind css with the JIT mode.

This depends on some additions from https://github.com/meteor/meteor/pull/11882. On older versions of Meteor, there is no way for minifiers to add files to the watch set. I'm not sure how you want to handle compatibility with older Meteor versions.