### PR TITLE
Release 3.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: 'Minifier for Meteor with PostCSS processing - use Autoprefixer and others with ease',
-  version: '2.0.8',
+  version: '3.0.0-alpha.19',
   name: 'juliancwirko:postcss',
   git: 'https://github.com/juliancwirko/meteor-postcss.git'
 });
@@ -9,7 +9,7 @@ Package.registerBuildPlugin({
   name: 'minifier-postcss',
   use: [
     'ecmascript@0.15.2',
-    'minifier-css@1.5.4',
+    'minifier-css@1.5.4 || 2.0.0-alpha300.19',
     'tmeasday:check-npm-versions@1.0.2'
   ],
   npmDependencies: {


### PR DESCRIPTION
This PR removes the Fibers dependency and uses async/await instead.

Also fixes package dependency conflicts.

Note: I could have rewritten a lot to ES6 and bump NPM dependencies but I would rather do that in the next PRs.