### PR TITLE
fix: add a not relative to compatibility with Meteor 2 only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # PostCSS Plugin For Meteor
 
+## Compatibility
+
+**This package is only compatible with Meteor 2**. 
+Meteor 3 can use `postcss` using the `standard-minifier-css` package
+
+## Presentation
+
 Meteor CSS Minifier with [PostCSS](https://github.com/postcss/postcss) processing.
 
 This package allows you to use PostCSS plugins with **.css files**. You can add your custom plugins by adding Npm packages using `package.json`. You can also use your favourite preprocessor side by side with this package. It allows you to enable many PostCSS plugins, for example **Autoprefixer** for all preprocessors you use. (Of course you can use it whithout any preprocessor too).


### PR DESCRIPTION
I came around because I have an issue with post css with Meteor 3, and I forgot that this package was not necessary anymore. I had to read through the PR for Meteor 3 last message https://github.com/Meteor-Community-Packages/meteor-postcss/pull/61#issuecomment-2096327514 to get my mistake.

Hence here is a proposal for a simple note to avoid further confusion